### PR TITLE
Add SvelteKit

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -24,6 +24,7 @@
 { "name": "Astro", "crawlerStart": "https://docs.astro.build/en/", "crawlerPrefix": "https://docs.astro.build/en/" }
 { "name": "Elixir", "crawlerStart": "https://elixir-lang.org/docs.html", "crawlerPrefix": "https://elixir-lang.org/docs.html" }
 { "name": "Svelte", "crawlerStart": "https://svelte.dev/docs", "crawlerPrefix": "https://svelte.dev/docs" }
+{ "name": "SvelteKit", "crawlerStart": "https://kit.svelte.dev/docs/introduction", "crawlerPrefix": "https://kit.svelte.dev/docs" }
 { "name": "PineconeDB", "crawlerStart": "https://docs.pinecone.io/docs/", "crawlerPrefix": "https://docs.pinecone.io/docs/" }
 { "name": "Redis", "crawlerStart": "https://redis.io/docs/", "crawlerPrefix": "https://redis.io/docs/" }
 { "name": "KeyDB", "crawlerStart": "https://docs.keydb.dev/docs/", "crawlerPrefix": "https://docs.keydb.dev/docs/" }


### PR DESCRIPTION
SvelteKit is the part that does routing, server-side rendering and all the other backend stuff. When people say Svelte, they usually mean SvelteKit.