### PR TITLE
Add SQLFluff and Ruff to docs.jsonl

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -367,3 +367,5 @@
 { "name": "Amazon EC2", "crawlerStart": "https://docs.aws.amazon.com/ec2/index.html", "crawlerPrefix": "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/" }
 { "name": "Aws Lambda", "crawlerStart": "https://docs.aws.amazon.com/lambda/index.html", "crawlerPrefix": "https://docs.aws.amazon.com/lambda/latest/dg/" }
 { "name": "Mantis", "crawlerStart": "https://www.mantisbt.org/documentation.php", "crawlerPrefix": "https://www.mantisbt.org/docs/master/en-US/Developers_Guide/" }
+{ "name": "SQLFluff", "crawlerStart": "https://docs.sqlfluff.com/en/stable/", "crawlerPrefix": "https://docs.sqlfluff.com/en/stable/" }
+{ "name": "Ruff", "crawlerStart": "https://beta.ruff.rs/docs/", "crawlerPrefix": "https://beta.ruff.rs/docs/" }


### PR DESCRIPTION
Add Documentation links for SQLFluff and Ruff. Both of these are linters with extensive configuration where having an AI assistant in doing the proper configuration would be a significant improvement for the developer. The difficult part with these is configuration files are typically slowly changing so it is less likely that developers know the patterns and configurations by heart. They are more likely to spend significant time the documentation to get the configurations correct.