### PR TITLE
feat: Add Novu docs

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -373,3 +373,4 @@
 { "name": "Ruff", "crawlerStart": "https://beta.ruff.rs/docs/", "crawlerPrefix": "https://beta.ruff.rs/docs/" }
 { "name": "FusionAuth API", "crawlerStart": "https://fusionauth.io/docs/v1/tech/apis/", "crawlerPrefix": "https://fusionauth.io/docs/v1/tech/apis/" }
 { "name": "Serp Google Scholar API", "crawlerStart": "https://serpapi.com/google-scholar-api", "crawlerPrefix": "https://serpapi.com/google-scholar-api" }
+{ "name": "Novu", "crawlerStart": "https://docs.novu.co/", "crawlerPrefix": "https://docs.novu.co/" }


### PR DESCRIPTION
Add documentation for Novu, the open-source notification infrastructure.
* https://docs.novu.co/
* https://github.com/novuhq/novu