### PR TITLE
Adds the Crystal language std lib docs and the Amber framework to the docs

### DIFF
--- a/docs.jsonl
+++ b/docs.jsonl
@@ -376,3 +376,5 @@
 { "name": "Serp Google Scholar API", "crawlerStart": "https://serpapi.com/google-scholar-api", "crawlerPrefix": "https://serpapi.com/google-scholar-api" }
 { "name": "Novu", "crawlerStart": "https://docs.novu.co/", "crawlerPrefix": "https://docs.novu.co/" }
 { "name": "Drizzle", "crawlerStart": "https://orm.drizzle.team/docs/overview", "crawlerPrefix": "https://orm.drizzle.team/docs/overview" }
+{ "name": "Crystal", "crawlerStart": "https://crystal-lang.org/api", "crawlerPrefix": "https://crystal-lang.org/api" }
+{ "name": "Amber", "crawlyerStart": "https://docs.amberframework.org/amber", "crawlerPrefix": "https://docs.amberframework.org/amber" }

--- a/docs.jsonl
+++ b/docs.jsonl
@@ -377,4 +377,4 @@
 { "name": "Novu", "crawlerStart": "https://docs.novu.co/", "crawlerPrefix": "https://docs.novu.co/" }
 { "name": "Drizzle", "crawlerStart": "https://orm.drizzle.team/docs/overview", "crawlerPrefix": "https://orm.drizzle.team/docs/overview" }
 { "name": "Crystal", "crawlerStart": "https://crystal-lang.org/api", "crawlerPrefix": "https://crystal-lang.org/api" }
-{ "name": "Amber", "crawlyerStart": "https://docs.amberframework.org/amber", "crawlerPrefix": "https://docs.amberframework.org/amber" }
+{ "name": "Amber", "crawlerStart": "https://docs.amberframework.org/amber", "crawlerPrefix": "https://docs.amberframework.org/amber" }


### PR DESCRIPTION
Here I've added the std lib docs for Crystal, the language itself has additional docs that ultimately lead to the std lib docs, but I wasn't sure how you're crawler would find it so I just went straight to the std lib. The two have different base URLs, so I couldn't figure out a way to include both the std lib and the language reference itself as a single entry.

Amber's documentation is much more straight forward.