### PR TITLE
Fix grammatical error in .cursorrules description

### DIFF
--- a/context/rules-for-ai.mdx
+++ b/context/rules-for-ai.mdx
@@ -14,4 +14,4 @@ This custom instruction will be included for features such as Cursor Chat and Ct
 
 For project-specific instructions, you can include the instructions in a `.cursorrules` file in the root of your project.
 
-As the same as the "Rules for AI" section, the instructions in the `.cursorrules` file will be included for features such as Cursor Chat and Ctrl/⌘ K.
+Similar to the 'Rules for AI' section, the instructions in the .cursorrules file will be included for features such as Cursor Chat and Ctrl/⌘ K.


### PR DESCRIPTION
This pull request corrects a grammatical error in the description of the .cursorrules file functionality.

Changes made:

Replaced 'As the same as' with 'Similar to' for better clarity and grammar.