### PR TITLE
Fix @ symbols link in overview documentation

### DIFF
--- a/cmdk/overview.mdx
+++ b/cmdk/overview.mdx
@@ -11,7 +11,7 @@ Cmd K, also known or "Ctrl K" on Windows/Linux, allows you to generate new code 
 ### Prompt Bars 
 
 In Cursor, we call the bar that appears when you press `Ctrl/Cmd K` the "Prompt Bar". It works similarly to the AI input box for chat, in 
-which you can type normally, or use [@ symbols](context/@-symbols) to reference other context. 
+which you can type normally, or use [@ symbols](/context/@-symbols) to reference other context. 
 
 
 ### Inline Generation


### PR DESCRIPTION
### Pull Request Description

**Summary:**
This pull request includes updates to the `cmdk/overview.mdx` file in the documentation. 

**Changes:**
- Corrected a broken link in the Prompt Bars section:
  - Changed `[context/@-symbols](context/@-symbols)` to `[context/@-symbols](/context/@-symbols)`.

**Details:**
- **File:** `cmdk/overview.mdx`
  - **Section:** Prompt Bars
  - **Modification:** Fixed the link to correctly reference the context.

This update ensures that the link properly directs users to the correct section for additional context.

**Additional Notes:**
Please review the changes and provide any feedback or additional improvements. Thank you!

Feel free to modify this description to add any other relevant details or information.