### PR TITLE
Feat: Add security section with domains for whitelisting

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -128,7 +128,8 @@
     {
       "group": "Privacy",
       "pages": [
-        "privacy/privacy"
+        "privacy/privacy",
+        "security/security",
       ]
     },    
     {

--- a/mint.json
+++ b/mint.json
@@ -129,7 +129,7 @@
       "group": "Privacy",
       "pages": [
         "privacy/privacy",
-        "security/security",
+        "security/security"
       ]
     },    
     {

--- a/mint.json
+++ b/mint.json
@@ -128,7 +128,12 @@
     {
       "group": "Privacy",
       "pages": [
-        "privacy/privacy",
+        "privacy/privacy"
+      ]
+    },    
+    {
+      "group": "Security",
+      "pages": [
         "security/security"
       ]
     },    

--- a/security/security.mdx
+++ b/security/security.mdx
@@ -1,0 +1,20 @@
+---
+title: Security FAQ
+---
+
+### What domains should I whitelist when using Cursor behind a corporate VPN/proxy?
+
+If you're behind a corporate proxy, whitelist these domains to ensure that Cursor works correctly:
+
+- Most API requests: **api2.cursor.sh**
+- Cursor Tab requests (HTTP/2 only): **api3.cursor.sh**
+- Codebase indexing (HTTP/2 only): **repo42.cursor.sh**
+- Cursor Tab requests depending on your location (HTTP/2 only):
+  - **api4.cursor.sh**
+  - **us-asia.gcpp.cursor.sh**
+  - **us-eu.gcpp.cursor.sh**
+  - **us-only.gcpp.cursor.sh**
+- Downloading extensions from the extension marketplace:
+  - **marketplace.cursorapi.com**
+  - **cursor-cdn.com**
+- Checking for and downloading updates: **download.todesktop.com**

--- a/security/security.mdx
+++ b/security/security.mdx
@@ -6,15 +6,15 @@ title: Security FAQ
 
 If you're behind a corporate proxy, whitelist these domains to ensure that Cursor works correctly:
 
-- Most API requests: **api2.cursor.sh**
-- Cursor Tab requests (HTTP/2 only): **api3.cursor.sh**
-- Codebase indexing (HTTP/2 only): **repo42.cursor.sh**
+- Most API requests: **https://api2.cursor.sh**
+- Cursor Tab requests (HTTP/2 only): **https://api3.cursor.sh**
+- Codebase indexing (HTTP/2 only): **https://repo42.cursor.sh**
 - Cursor Tab requests depending on your location (HTTP/2 only):
-  - **api4.cursor.sh**
-  - **us-asia.gcpp.cursor.sh**
-  - **us-eu.gcpp.cursor.sh**
-  - **us-only.gcpp.cursor.sh**
+  - **https://api4.cursor.sh**
+  - **https://us-asia.gcpp.cursor.sh**
+  - **https://us-eu.gcpp.cursor.sh**
+  - **https://us-only.gcpp.cursor.sh**
 - Downloading extensions from the extension marketplace:
-  - **marketplace.cursorapi.com**
-  - **cursor-cdn.com**
-- Checking for and downloading updates: **download.todesktop.com**
+  - **https://marketplace.cursorapi.com**
+  - **https://cursor-cdn.com**
+- Checking for and downloading updates: **https://download.todesktop.com**


### PR DESCRIPTION
## Updates

- Add security section with domains for whitelisting

### Reasoning

It's not clear based on the documentation, some domains should be whitelisted.

Only indexing error is clear based on the logs, for example:

```
...
2025-03-27 11:56:19.065 [info] Handshake start
2025-03-27 11:56:19.184 [error] Error Checking Connection: [internal] self signed certificate in certificate chain
2025-03-27 11:56:19.186 [info] Creating Indexing Repo client:  https://repo42.cursor.sh/
2025-03-27 11:56:19.186 [info] Creating repo client with backend url: https://repo42.cursor.sh/
2025-03-27 11:57:23.120 [warning] Retrying handshake with timeout 128000. Error:  [internal] self signed certificate in certificate chain
2025-03-27 11:57:23.122 [error] Handshake failed:
2025-03-27 11:57:23.122 [error] Error: timeout in handshake with retry
...
```